### PR TITLE
multiple typo fixes

### DIFF
--- a/ci/install_deps.py
+++ b/ci/install_deps.py
@@ -142,7 +142,7 @@ def arguments():
                         dest='global_install',
                         help="install the dependencies globaly")
     parser.add_argument('--no-tests', action='store_true',
-                        help="dont install cmocka_extensions & cmocka_mocks")
+                        help="don't install cmocka_extensions & cmocka_mocks")
     parser.add_argument('--no-mocks', action='store_true',
                         help="don't build & install mock libraries (no cmocka depenedencies)")
     parser.add_argument('--ci', action='store_true',

--- a/cmake/project.cmake
+++ b/cmake/project.cmake
@@ -101,7 +101,7 @@ function(project_set_version_variables)
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   if(NOT exit_code EQUAL 0)
-    message(WARNING "failed to retrive git short commit hash")
+    message(WARNING "failed to retrieve git short commit hash")
     set(git_output "none")
   endif()
   set(${ver_git_name} ${git_output} PARENT_SCOPE)

--- a/src/clients/coredump/index.rst
+++ b/src/clients/coredump/index.rst
@@ -1,7 +1,7 @@
 Coredump Client
 ===============
 
-The coredump client converts a coredump that has occured into an elos event. The coredump properties are set through the coredump client configuration file `coredump.json` file.
+The coredump client converts a coredump that has occurred into an elos event. The coredump properties are set through the coredump client configuration file `coredump.json` file.
 
 
 .. literalinclude:: /src/clients/coredump/coredump.json

--- a/src/components/eventdispatcher/public/elos/eventdispatcher/eventdispatcher.h
+++ b/src/components/eventdispatcher/public/elos/eventdispatcher/eventdispatcher.h
@@ -9,7 +9,7 @@
 __BEGIN_DECLS
 
 /*******************************************************************
- * Allocates space for and intialize an new EventDispatcher
+ * Allocates space for and initialize a new EventDispatcher
  *
  * Parameters:
  *   eventDispatcher:

--- a/src/components/plugincontrol/index.rst
+++ b/src/components/plugincontrol/index.rst
@@ -24,7 +24,7 @@ The available Plugin types are SCANNER, STORAGEBACKEND and CLIENTCONNECTION.
 The plugin types are currently still in its infant stages and will be extended
 in the near future, which will also result in additional documentation here.
 
-Each Plugin can be in three states: Unintialized, Loaded and Started.
+Each Plugin can be in three states: Uninitialized, Loaded and Started.
 The Plugin is "Uninitialized" until elosPluginControlLoad is called, which will
 open the shared object, verify its contents and creates a worker thread for
 the Plugin that will be sleeping until elosPluginControlStart is called.
@@ -32,7 +32,7 @@ After elosPluginControlLoad was called the Plugin is in the "Loaded" state.
 Once the Plugin is started, it will be running and in the "Started" state until
 elosPluginControlStop is called (after it will be in the "Loaded" state again).
 A stopped Plugin can be then unloaded with elosPluginControlUnload, putting it
-back into the "Unintialized" state. Note that Starting and Stopping a Plugin
+back into the "Uninitialized" state. Note that Starting and Stopping a Plugin
 multiple times is currently not supported, but will be added at a later stage,
 so a Plugin should make sure it is capable to do so.
 

--- a/src/elosd/main.c
+++ b/src/elosd/main.c
@@ -76,7 +76,7 @@ int elosServerShutdown(struct serverContext *ctx) {
         result = EXIT_FAILURE;
     }
     if (elosClientManagerDeleteMembers(&ctx->clientManagerContext) != SAFU_RESULT_OK) {
-        safuLogErr("Stoping client manager failed!");
+        safuLogErr("Stopping client manager failed!");
         result = EXIT_FAILURE;
     }
     if (elosStorageManagerStop(&ctx->storageManager) != SAFU_RESULT_OK) {
@@ -87,7 +87,7 @@ int elosServerShutdown(struct serverContext *ctx) {
         result = EXIT_FAILURE;
     }
     if (elosConnectionManagerStop(&ctx->connectionManagerContext) != SAFU_RESULT_OK) {
-        safuLogErr("Stoping connection manager failed!");
+        safuLogErr("Stopping connection manager failed!");
         result = EXIT_FAILURE;
     } else if (elosConnectionManagerDeleteMembers(&ctx->connectionManagerContext) != SAFU_RESULT_OK) {
         safuLogErr("Deleting connection manager failed!");

--- a/src/plugins/scanners/syslog/private/logline_mapper.c
+++ b/src/plugins/scanners/syslog/private/logline_mapper.c
@@ -207,7 +207,7 @@ static safuResultE_t _getFilterRule(const samconfConfig_t *config, size_t *ruleI
                         ++(*ruleIdx);
                     }
                 } else {
-                    safuLogErrF("invalid config: MessageCode \"%s\" has wrong formating!",
+                    safuLogErrF("invalid config: MessageCode \"%s\" has wrong formatting!",
                                 config->children[childItr]->key);
                 }
             } else {

--- a/src/plugins/storagebackends/dlt/private/dltLoggerBackend.c
+++ b/src/plugins/storagebackends/dlt/private/dltLoggerBackend.c
@@ -41,7 +41,7 @@ safuResultE_t elosDltLoggerBackendInit(elosDltLoggerBackend_t *dlt, elosDltLogge
 
         SAFU_PTHREAD_MUTEX_INIT_WITH_RESULT(&dlt->mutex, NULL, result)
         if (result != SAFU_RESULT_OK) {
-            safuLogErr("Failed to intialize mutex");
+            safuLogErr("Failed to initialize mutex");
         } else {
             dlt->dlt.pipePath = strdup(param->connectionString == NULL ? "/tmp/dlt" : param->connectionString);
             if (dlt->dlt.pipePath == NULL) {

--- a/src/plugins/storagebackends/influxdbbackend/private/InfluxDbBackend.c
+++ b/src/plugins/storagebackends/influxdbbackend/private/InfluxDbBackend.c
@@ -341,7 +341,7 @@ static inline bool _fillEventStruct(elosEvent_t *event, json_object *value, json
             safuLogErrF("Failed to parse data point at idx %i", idx);
         }
     } else {
-        safuLogErrF("could not retrive key at idx %i", idx);
+        safuLogErrF("could not retrieve key at idx %i", idx);
     }
 
     return filled;
@@ -491,12 +491,12 @@ safuResultE_t elosInfluxDbBackendFindEvents(elosStorageBackend_t *backend, elosE
                 if (filterResult == RPNFILTER_RESULT_MATCH) {
                     safuLogDebug("Append event: Match");
                 } else if (filterResult == RPNFILTER_RESULT_NO_MATCH) {
-                    safuLogDebug("Dont append event: No match");
+                    safuLogDebug("Don't append event: No match");
                     elosEventDeleteMembers(event);
                     safuVecRemove(events, i);
                 } else {
                     safuLogErr("elosEventFilterExecute failed");
-                    safuLogDebugF("Dont append Event: RPN filter result is: %d", filterResult);
+                    safuLogDebugF("Don't append Event: RPN filter result is: %d", filterResult);
                     elosEventDeleteMembers(event);
                     safuVecRemove(events, i);
                     res = SAFU_RESULT_FAILED;

--- a/test/index.rst
+++ b/test/index.rst
@@ -509,7 +509,7 @@ the user requirements. The default guidelines are as follows:
 
 -  The length of a robot keyword is set to 50
 -  A keyword can call a maximum of 20 other keywords inside it.
--  Since template test cases dont have keywords, check for too few calls
+-  Since template test cases don't have keywords, check for too few calls
    to keywords shall be avoided.
 -  Line width for robot tests are set to 100
 -  static checks shall only report log levels of above warning.

--- a/test/integration/scripts/robot_code_lint.sh
+++ b/test/integration/scripts/robot_code_lint.sh
@@ -25,7 +25,7 @@ static_code_check()
 
   RC_CHECK=$(echo $?)
 
-  echo "Found "$RC_CHECK" format errors in code" 
+  echo "Found "$RC_CHECK" format errors in code"
 }
 
 check_code()
@@ -35,7 +35,7 @@ check_code()
   RC_CHECK=$(robotidy --check $INTEGRATION_TEST_DIR ; echo $?)
 
   if [ $RC_CHECK -ne 0 ]; then
-      echo "Atleast one test/tests has formating error" 
+      echo "Atleast one test/tests has formatting error"
   fi
 }
 
@@ -58,9 +58,9 @@ print_help()
 {
     echo 
     echo "Usage: $0 --static_check <test> : Performs static code checks of given or all robot files"
-    echo "Usage: $0 --check <test> : Checks all or given test for formating errors"
+    echo "Usage: $0 --check <test> : Checks all or given test for formatting errors"
     echo "Usage: $0 --show <test>  : Shows suggested format changes for all or given tests with out writing them to files"
-    echo "Usage: $0 --check-show <test> : Checks for formating error and shows suggested changes for correcting them with out writing them to files"
+    echo "Usage: $0 --check-show <test> : Checks for formatting error and shows suggested changes for correcting them with out writing them to files"
     echo "Usage: $0 --show-fix <test>   : Shows format changes for correcting format errors and writes them to all or given files"
     echo "Usage: $0 --check-fix <test>  : Checks for format error and if any fix format errors with out showing what changes are done"
     echo "Usage: $0 --help"

--- a/test/smoketest/smoketest.sh
+++ b/test/smoketest/smoketest.sh
@@ -198,7 +198,7 @@ smoketest_client() {
     output_diff=$(diff $RESULT_DIR/client_output.txt $SMOKETEST_DIR/client_output.txt || echo "diff returned: $?")
     if [ -n "$output_diff" ]
     then
-        log_err "Problems occured while comparing the client output:"
+        log_err "Problems occurred while comparing the client output:"
         log_err "$output_diff"
         return 1
     fi

--- a/test/utest/components/eventprocessor/elosEventFilterNodeVectorDeleteMembers/case_success.c
+++ b/test/utest/components/eventprocessor/elosEventFilterNodeVectorDeleteMembers/case_success.c
@@ -26,7 +26,7 @@ int elosTestEloEventFilterNodeVectorDeleteMembersSuccessSetup(void **state) {
 int elosTestEloEventFilterNodeVectorDeleteMembersSuccessTeardown(void **state) {
     elosTestState_t *test = *state;
 
-    // dont free the created objects. If they are not freed already, the function failed the test
+    // don't free the created objects. If they are not freed already, the function failed the test
 
     free(test);
 


### PR DESCRIPTION
Some were discovered while running `lintian` on elos debian binary packages.
This should fix `lintian` info message: 'spelling-error-in-binary'