### PR TITLE
debian.native: set libmock-libelos0 section to libs

### DIFF
--- a/debian.native/control
+++ b/debian.native/control
@@ -249,7 +249,7 @@ Description: Event logging and management with normalized output-format coredump
  Coredump utility package.
 
 Package: libmock-libelos0
-Section: libdevel
+Section: libs
 Architecture: any
 Depends:
  ${misc:Depends},


### PR DESCRIPTION
Rebase of: https://github.com/Elektrobit/elos/pull/9/commits/4ef820e0049b76084d04872381ecb176d3daf408