### PR TITLE
Initialize socketFd to -1 in dltLoggerBackend

### DIFF
--- a/src/plugins/storagebackends/dlt/private/dltLoggerBackend.c
+++ b/src/plugins/storagebackends/dlt/private/dltLoggerBackend.c
@@ -38,6 +38,7 @@ safuResultE_t elosDltLoggerBackendInit(elosDltLoggerBackend_t *dlt, elosDltLogge
         safuLogErr("Null parameter given");
     } else {
         memset(&dlt->dlt, 0, sizeof(dlt->dlt));
+        dlt->dlt.socketFd = -1;
 
         SAFU_PTHREAD_MUTEX_INIT_WITH_RESULT(&dlt->mutex, NULL, result)
         if (result != SAFU_RESULT_OK) {


### PR DESCRIPTION
The `elosDltConnection_t` type documents that socketFd must be `-1` when not connected.  The `memset()` in `elosDltLoggerBackendInit()` zeroes the whole struct, leaving `socketFd` at 0 (i.e. `stdin`/`stdout`).

When the DLT daemon is not running, elosDltConnectPipe() fails to open `/tmp/dlt` and returns early without setting `socketFd`.  Any subsequent call to `elosDltSendUserLog()` or `elosDltUnregisterContext()` therefore calls `safuWriteExactly(0, ...)`, which writes DLT protocol frames (containing the `{'D','U','H',0x01}` magic bytes) to `stdout`.  This causes spurious "DUH" output on the serial console during boot.

Fix by explicitly setting `socketFd = -1` after the `memset`. `safuWriteExactly()` already rejects fd < 0, so all writes to an unconnected backend will silently fail.